### PR TITLE
Fixing an OS dependent issue with the script.

### DIFF
--- a/exercises/exercise.sh
+++ b/exercises/exercise.sh
@@ -26,7 +26,7 @@ function stage() {
 
     echo "STAGING $EXERCISE"
 
-    cp -r $STAGING_DIR/$EXERCISE/ $EXERCISE_DIR
+    cp -r $STAGING_DIR/$EXERCISE/. $EXERCISE_DIR
 }
 
 function solve() {
@@ -39,7 +39,7 @@ function solve() {
     if [ -z $FILE_FILTER ]; then
         echo "SOLVING $EXERCISE"
     
-        cp -r $SOLUTION/ $EXERCISE_DIR
+        cp -r $SOLUTION/. $EXERCISE_DIR
     else
         WORKING_DIR=$(pwd)
         cd $SOLUTION


### PR DESCRIPTION
The `exercise.sh` script was working fine on Mac. However, on Linux machines, it would create unnecessary subfolders whenever it copied files.

This change should prevent the creation of those subfolders and allow the script to work correctly on Linux as well as Mac